### PR TITLE
fix: max appname length in conn string

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -98,6 +98,9 @@ func NewConnWithHooks(ctx context.Context, info *Info, envChangeHooks []tds.EnvC
 	}
 
 	loginConfig.AppName = info.AppName
+	if len(loginConfig.AppName) > 30 {
+		loginConfig.AppName = loginConfig.AppName[:30]
+	}
 
 	if err := conn.Channel.Login(ctx, loginConfig); err != nil {
 		conn.Close()


### PR DESCRIPTION
Fixes https://github.com/newrelic/nri-flex/issues/512
